### PR TITLE
OCI specific changes for Secor

### DIFF
--- a/kubernetes/helm_charts/secor/config/secor.common.properties
+++ b/kubernetes/helm_charts/secor/config/secor.common.properties
@@ -23,12 +23,12 @@ secor.kafka.topic_blacklist=
 
 # Choose what to fill according to the service you are using
 # in the choice option you can fill S3, GS, Swift or Azure
-cloud.service=Azure
+cloud.service={{ $.Values.storage_type }}
 
 # AWS authentication credentials.
 # Leave empty if using IAM role-based authentication with s3a filesystem.
-aws.access.key=
-aws.secret.key=
+aws.access.key={{ $.Values.s3_access_key }}
+aws.secret.key={{ $.Values.s3_secret_id }}
 aws.role=
 
 # Optional Proxy Setting. Set to true to enable proxy
@@ -51,12 +51,12 @@ aws.proxy.http.port=
 # secor.upload.manager.class.
 #
 # http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
-aws.region=
-aws.endpoint=
+aws.region={{ $.Values.s3_region }}
+aws.endpoint={{ $.Values.s3_endpoint }}
 
 # Toggle the AWS S3 client between virtual host style access and path style
 # access. See http://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html
-aws.client.pathstyleaccess=false
+aws.client.pathstyleaccess={{ $.Values.s3_path_style_access }}
 
 ###########################
 # START AWS S3 ENCRYPTION #

--- a/kubernetes/helm_charts/secor/config/secor.common.properties
+++ b/kubernetes/helm_charts/secor/config/secor.common.properties
@@ -357,7 +357,8 @@ secor.max.message.size.bytes=100000
 
 # Class that will manage uploads. Default is to use the hadoop
 # interface to S3.
-secor.upload.manager.class=com.pinterest.secor.uploader.AzureUploadManager
+# secor.upload.manager.class=com.pinterest.secor.uploader.AzureUploadManager
+secor.upload.manager.class=com.pinterest.secor.uploader.S3UploadManager
 
 #Set below property to your timezone, and the events will be parsed and converted to the timezone specified
 secor.message.timezone=UTC

--- a/kubernetes/helm_charts/secor/config/secor.partition.properties
+++ b/kubernetes/helm_charts/secor/config/secor.partition.properties
@@ -14,7 +14,9 @@
 # limitations under the License.
 
 include=secor.properties
+{{- if eq .Values.storage_type "Azure" }}
 include=secor.azure.properties
+{{- end }}
 
 # Name of the Kafka consumer group.
 secor.kafka.group={{ get (get $.Values.secor_jobs $.Release.Name) "consumer_group" }}

--- a/kubernetes/helm_charts/secor/config/secor.partition.properties
+++ b/kubernetes/helm_charts/secor/config/secor.partition.properties
@@ -23,7 +23,7 @@ secor.kafka.group={{ get (get $.Values.secor_jobs $.Release.Name) "consumer_grou
 secor.message.parser.class={{ get (get $.Values.secor_jobs $.Release.Name) "message_parser" }}
 
 # S3 path where sequence files are stored.
-secor.s3.path=
+secor.s3.path={{- get (get $.Values.secor_jobs $.Release.Name) "base_path" }}
 
 # Swift path where sequence files are stored.
 secor.swift.path=secor_dev/partition

--- a/kubernetes/helm_charts/secor/config/secor.properties
+++ b/kubernetes/helm_charts/secor/config/secor.properties
@@ -10,7 +10,7 @@ include=secor.common.properties
 ###############
 
 # Name of the s3 bucket where log files are stored.
-secor.s3.bucket=
+secor.s3.bucket={{ $.Values.s3_bucket_name }}
 
 ###############
 # Using Swift #

--- a/kubernetes/helm_charts/secor/values.j2
+++ b/kubernetes/helm_charts/secor/values.j2
@@ -11,15 +11,15 @@ s3_bucket_name: "telemetry-data-store"
 
 {% if cloud_service_provider == 'oci' -%}
 storage_type: "S3"
-secor_storage_class: "oci-bv"
+storageClass: "oci-bv"
 {%- else -%}
 storage_type: "Azure"
+storageClass: {{ secor_storage_class | default('default') }}
 {%- endif %}
 
 
 
 namespace: {{ secor_namespace }}
-storageClass: {{ secor_storage_class | default('default') }}
 imagepullsecrets: {{ imagepullsecrets }}
 
 secor_jobs:

--- a/kubernetes/helm_charts/secor/values.j2
+++ b/kubernetes/helm_charts/secor/values.j2
@@ -11,6 +11,7 @@ s3_bucket_name: "telemetry-data-store"
 
 {% if cloud_service_provider == 'oci' -%}
 storage_type: "S3"
+secor_storage_class: "oci-bv"
 {%- else -%}
 storage_type: "Azure"
 {%- endif %}

--- a/kubernetes/helm_charts/secor/values.j2
+++ b/kubernetes/helm_charts/secor/values.j2
@@ -2,6 +2,21 @@ azure_account: "{{ sunbird_private_storage_account_name }}"
 azure_secret: "{{ sunbird_private_storage_account_key }}"
 azure_container_name: "telemetry-data-store"
 
+s3_access_key: "{{s3_storage_key}}"
+s3_secret_id: "{{s3_storage_secret}}"
+s3_region: "{{oci_region}}"
+s3_endpoint: "{{s3_storage_endpoint}}"
+s3_path_style_access: "{{s3_path_style_access}}"
+s3_bucket_name: "telemetry-data-store"
+
+{% if cloud_service_provider == 'oci' -%}
+storage_type: "S3"
+{%- else -%}
+storage_type: "Azure"
+{%- endif %}
+
+
+
 namespace: {{ secor_namespace }}
 storageClass: {{ secor_storage_class | default('default') }}
 imagepullsecrets: {{ imagepullsecrets }}


### PR DESCRIPTION
Secor is used to persist data from kafka topics. 
In its current state its configured for azure
For block volume its hard code to use azure block volume. This has been changed to oci specific storage class for block volume provision if the csp is OCI
Currently its configure to talk to only azure blob storage. This change is to support oci oss by using s3 compliant api.  

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Deploy/DataPipeline/Secor

- [X] Secor pods starting up and interacting with oci object storage
- [X] Creating oci block volume for persistent storage