### PR TITLE
Oci 5.1.0 influxdb

### DIFF
--- a/ansible/roles/influxdb/tasks/main.yml
+++ b/ansible/roles/influxdb/tasks/main.yml
@@ -30,7 +30,7 @@
   wait_for: port=8086 timeout=60
 
 - name: Create monitoring_events database
-  command: /usr/bin/influx -execute "CREATE DATABASE {{ monitoring_db }}"
+  command: /usr/bin/influxd -execute "CREATE DATABASE {{ monitoring_db }}"
 
 - name: Check if influxdb_relay_deb_package_name is installed
   command: dpkg-query -W {{ influxdb_relay_deb_package_name }}

--- a/ansible/roles/influxdb/tasks/main.yml
+++ b/ansible/roles/influxdb/tasks/main.yml
@@ -30,7 +30,7 @@
   wait_for: port=8086 timeout=60
 
 - name: Create monitoring_events database
-  command: /usr/bin/influxd -execute "CREATE DATABASE {{ monitoring_db }}"
+  command: /usr/bin/influx -execute "CREATE DATABASE {{ monitoring_db }}"
 
 - name: Check if influxdb_relay_deb_package_name is installed
   command: dpkg-query -W {{ influxdb_relay_deb_package_name }}

--- a/ansible/roles/influxdb/tasks/main.yml
+++ b/ansible/roles/influxdb/tasks/main.yml
@@ -2,11 +2,11 @@
 #- name: Set hostname
   #hostname: name={{ ansible_hostname }}
 
-#- name: Import InfluxDB GPG signing key
-#  apt_key: url=https://repos.influxdata.com/influxdb.key state=present
+- name: Import InfluxDB GPG signing key
+  apt_key: url=https://repos.influxdata.com/influxdata-archive_compat.key state=present
 
-#- name: Add InfluxDB repository
-#  apt_repository: repo='deb https://repos.influxdata.com/ubuntu trusty stable' state=present
+- name: Add InfluxDB repository
+  apt_repository: repo='deb https://repos.influxdata.com/ubuntu trusty stable' state=present
 
 - name: Install InfluxDB packages
   apt: name=influxdb state=present

--- a/ansible/roles/influxdb/tasks/main.yml
+++ b/ansible/roles/influxdb/tasks/main.yml
@@ -12,6 +12,10 @@
   apt: name=influxdb state=present
   notify: restart influxdb service
 
+- name: Install InfluxDB client packages
+  apt: name=influxdb-client state=present
+  notify: restart influxdb service
+
 - name: Replace InfluxDB cluster configuration
   template:
     dest: "/etc/influxdb/influxdb.conf"

--- a/ansible/roles/influxdb/tasks/main.yml
+++ b/ansible/roles/influxdb/tasks/main.yml
@@ -2,11 +2,11 @@
 #- name: Set hostname
   #hostname: name={{ ansible_hostname }}
 
-- name: Import InfluxDB GPG signing key
-  apt_key: url=https://repos.influxdata.com/influxdb.key state=present
+#- name: Import InfluxDB GPG signing key
+#  apt_key: url=https://repos.influxdata.com/influxdb.key state=present
 
-- name: Add InfluxDB repository
-  apt_repository: repo='deb https://repos.influxdata.com/ubuntu trusty stable' state=present
+#- name: Add InfluxDB repository
+#  apt_repository: repo='deb https://repos.influxdata.com/ubuntu trusty stable' state=present
 
 - name: Install InfluxDB packages
   apt: name=influxdb state=present


### PR DESCRIPTION
1. Influxdb rotated their key.
Was able to resolve it by changing the key in https://github.com/Sunbird-Obsrv/sunbird-data-pipeline/blob/release-5.1.0/ansible/roles/influxdb/tasks/main.yml as suggested in https://www.influxdata.com/blog/linux-package-signing-key-rotation/.

2. Influxdb client package is not available by default
Looks like the influxdb pacakge installation doesn't automatically install the influx cli. It's resolved by adding the respective package influxdb-client 