### PR TITLE
Oci 5.1.0 GitHub issue 33

### DIFF
--- a/ansible/roles/portal-dashboard/tasks/main.yml
+++ b/ansible/roles/portal-dashboard/tasks/main.yml
@@ -8,11 +8,6 @@
   tags:
     - common
 
-- name: Install virtualenv via pip
-  pip:
-    name: virtualenv
-    executable: pip3
-
 - name: Installing package
   pip:
     name: "{{library_path}}"

--- a/ansible/roles/portal-dashboard/tasks/main.yml
+++ b/ansible/roles/portal-dashboard/tasks/main.yml
@@ -12,7 +12,7 @@
   pip:
     name: "{{library_path}}"
     virtualenv: "{{ virtualenv_path }}"
-    virtualenv_python: "python3.6"
+    virtualenv_python: "python3.10"
   tags:
     - common
 

--- a/ansible/roles/portal-dashboard/tasks/main.yml
+++ b/ansible/roles/portal-dashboard/tasks/main.yml
@@ -8,11 +8,16 @@
   tags:
     - common
 
+- name: Install virtualenv via pip
+  pip:
+    name: virtualenv
+    executable: pip3
+
 - name: Installing package
   pip:
     name: "{{library_path}}"
     virtualenv: "{{ virtualenv_path }}"
-    virtualenv_python: "python3.10"
+    virtualenv_python: "python3.6"
   tags:
     - common
 

--- a/ansible/roles/portal-dashboard/tasks/main.yml
+++ b/ansible/roles/portal-dashboard/tasks/main.yml
@@ -17,7 +17,7 @@
   pip:
     name: "{{library_path}}"
     virtualenv: "{{ virtualenv_path }}"
-    virtualenv_python: "python3.6"
+    # virtualenv_python: "python3.6"
   tags:
     - common
 


### PR DESCRIPTION
Ubuntu 22.04 is coming with default python 3.10 version and virtual environment creation is always failing when explicitly virtualenv_python value to pip task in ansible. As per the documentation of ansible(https://docs.ansible.com/ansible/latest/collections/ansible/builtin/pip_module.html),
virtualenv_python : The Python executable used for creating the virtual environment. For example python3.5, python2.7. When not specified, the Python version used to run the ansible module is used.

made the change to remove the virtualenv_python attribute from ansible pip install task in https://github.com/ocisunbird/sunbird-data-pipeline/blob/oci-5.1.0-github-issue-33/ansible/roles/portal-dashboard/tasks/main.yml

The job went fine against the branch oci-5.1.0-github-issue-33 in https://github.com/ocisunbird/sunbird-data-pipeline.git